### PR TITLE
Corrected broken .JAR library paths by using relative paths.

### DIFF
--- a/MotorPHPayrollGR/nbproject/project.properties
+++ b/MotorPHPayrollGR/nbproject/project.properties
@@ -35,28 +35,27 @@ dist.jlink.dir=${dist.dir}/jlink
 dist.jlink.output=${dist.jlink.dir}/MotorPHPayrollGR
 endorsed.classpath=
 excludes=
-# --- Cleaned up Library References (One relative path per JAR) ---
-file.reference.commons-lang3-3.17.0.jar=CP-2-Group 2-JAR/commons-lang3-3.17.0.jar
-file.reference.itextpdf-5.5.13.3.jar=CP-2-Group 2-JAR/itextpdf-5.5.13.3.jar
-file.reference.jackcess-4.0.8.jar=CP-2-Group 2-JAR/jackcess-4.0.8.jar
-file.reference.jcalendar-1.4.jar=CP-2-Group 2-JAR/jcalendar-1.4.jar
-file.reference.jgoodies-common-1.2.0.jar=CP-2-Group 2-JAR/jgoodies-common-1.2.0.jar
-file.reference.jgoodies-looks-2.4.1.jar=CP-2-Group 2-JAR/jgoodies-looks-2.4.1.jar
-file.reference.junit-4.6.jar=CP-2-Group 2-JAR/junit-4.6.jar
-file.reference.opencsv-5.11.jar=CP-2-Group 2-JAR/opencsv-5.11.jar
+file.reference.commons-lang3-3.17.0.jar=lib\\commons-lang3-3.17.0.jar
+file.reference.itextpdf-5.5.13.3.jar=lib\\itextpdf-5.5.13.3.jar
+file.reference.jackcess-4.0.8.jar=lib\\jackcess-4.0.8.jar
+file.reference.jcalendar-1.4.jar=lib\\jcalendar-1.4.jar
+file.reference.jgoodies-common-1.2.0.jar=lib\\jgoodies-common-1.2.0.jar
+file.reference.jgoodies-looks-2.4.1.jar=lib\\jgoodies-looks-2.4.1.jar
+file.reference.junit-4.6.jar=lib\\junit-4.6.jar
+file.reference.opencsv-5.11.jar=lib\\opencsv-5.11.jar
 # --- End of Library References ---
 includes=**
 jar.compress=false
 # --- Cleaned up Classpath ---
 javac.classpath=\
     ${libs.absolutelayout.classpath}:\
+    ${file.reference.commons-lang3-3.17.0.jar}:\
+    ${file.reference.itextpdf-5.5.13.3.jar}:\
+    ${file.reference.jackcess-4.0.8.jar}:\
     ${file.reference.jcalendar-1.4.jar}:\
     ${file.reference.jgoodies-common-1.2.0.jar}:\
     ${file.reference.jgoodies-looks-2.4.1.jar}:\
     ${file.reference.junit-4.6.jar}:\
-    ${file.reference.commons-lang3-3.17.0.jar}:\
-    ${file.reference.itextpdf-5.5.13.3.jar}:\
-    ${file.reference.jackcess-4.0.8.jar}:\
     ${file.reference.opencsv-5.11.jar}
 # --- End of Classpath ---
 # Space-separated list of extra javac options

--- a/MotorPHPayrollGR/nbproject/project.properties
+++ b/MotorPHPayrollGR/nbproject/project.properties
@@ -37,21 +37,13 @@ endorsed.classpath=
 excludes=
 # --- Cleaned up Library References (One relative path per JAR) ---
 file.reference.commons-lang3-3.17.0.jar=CP-2-Group 2-JAR/commons-lang3-3.17.0.jar
-file.reference.commons-lang3-3.17.0.jar-1=lib\\commons-lang3-3.17.0.jar
 file.reference.itextpdf-5.5.13.3.jar=CP-2-Group 2-JAR/itextpdf-5.5.13.3.jar
-file.reference.itextpdf-5.5.13.3.jar-1=lib\\itextpdf-5.5.13.3.jar
 file.reference.jackcess-4.0.8.jar=CP-2-Group 2-JAR/jackcess-4.0.8.jar
-file.reference.jackcess-4.0.8.jar-1=lib\\jackcess-4.0.8.jar
 file.reference.jcalendar-1.4.jar=CP-2-Group 2-JAR/jcalendar-1.4.jar
-file.reference.jcalendar-1.4.jar-1=lib\\jcalendar-1.4.jar
 file.reference.jgoodies-common-1.2.0.jar=CP-2-Group 2-JAR/jgoodies-common-1.2.0.jar
-file.reference.jgoodies-common-1.2.0.jar-1=lib\\jgoodies-common-1.2.0.jar
 file.reference.jgoodies-looks-2.4.1.jar=CP-2-Group 2-JAR/jgoodies-looks-2.4.1.jar
-file.reference.jgoodies-looks-2.4.1.jar-1=lib\\jgoodies-looks-2.4.1.jar
 file.reference.junit-4.6.jar=CP-2-Group 2-JAR/junit-4.6.jar
-file.reference.junit-4.6.jar-1=lib\\junit-4.6.jar
 file.reference.opencsv-5.11.jar=CP-2-Group 2-JAR/opencsv-5.11.jar
-file.reference.opencsv-5.11.jar-1=lib\\opencsv-5.11.jar
 # --- End of Library References ---
 includes=**
 jar.compress=false
@@ -65,15 +57,7 @@ javac.classpath=\
     ${file.reference.commons-lang3-3.17.0.jar}:\
     ${file.reference.itextpdf-5.5.13.3.jar}:\
     ${file.reference.jackcess-4.0.8.jar}:\
-    ${file.reference.opencsv-5.11.jar}:\
-    ${file.reference.commons-lang3-3.17.0.jar-1}:\
-    ${file.reference.itextpdf-5.5.13.3.jar-1}:\
-    ${file.reference.jackcess-4.0.8.jar-1}:\
-    ${file.reference.jcalendar-1.4.jar-1}:\
-    ${file.reference.jgoodies-common-1.2.0.jar-1}:\
-    ${file.reference.jgoodies-looks-2.4.1.jar-1}:\
-    ${file.reference.junit-4.6.jar-1}:\
-    ${file.reference.opencsv-5.11.jar-1}
+    ${file.reference.opencsv-5.11.jar}
 # --- End of Classpath ---
 # Space-separated list of extra javac options
 javac.compilerargs=--enable-preview


### PR DESCRIPTION
This pull request addresses an issue where the project fails to build for collaborators after cloning from GitHub. The root cause was that NetBeans stored absolute paths to the JAR dependencies in the nbproject/project.properties file, causing build errors on any machine other than the original author's.

Changes Made:

1. Removed Existing JARs: All libraries with absolute paths were removed from the project's "Libraries" folder.
2. Re-added JARs with Relative Paths: The same JARs were re-added, but this time they were selected from the lib folder located within the project's root directory.
3. Updated Project Properties: The nbproject/project.properties file is now updated to reference the libraries with a relative path (e.g., ../lib/some.jar).
4. By storing the JARs directly in the repository and pointing to them relatively, anyone who clones the project will now have a working build environment out of the box.